### PR TITLE
Make Transactions preference compatible

### DIFF
--- a/Model/Checkout/Payment/MonduPlaceOrderService.php
+++ b/Model/Checkout/Payment/MonduPlaceOrderService.php
@@ -114,7 +114,7 @@ class MonduPlaceOrderService extends AbstractPlaceOrderService implements PlaceO
     {
         $component->getEvaluationResultBatch()->push(
             $component->getEvaluationResultBatch()->getFactory()->createErrorMessage(
-                __('Order placement failed: %1', $exception->getMessage())
+                (string) __('Order placement failed: %1', $exception->getMessage())
             )
         );
         $component->dispatchBrowserEvent('process-stop');


### PR DESCRIPTION
.. and fix parent constructor call, and cast a Phrase to string where needed.

I have applied this patch to make sure that `setup:di:compile` doesn't break and the checkout actually works.